### PR TITLE
japanize-matplotlibを追加する

### DIFF
--- a/environment-windows.yml
+++ b/environment-windows.yml
@@ -16,3 +16,4 @@ dependencies:
   - pip
   - pip:
     - schemdraw
+    - japanize-matplotlib

--- a/environment.yml
+++ b/environment.yml
@@ -17,3 +17,4 @@ dependencies:
   - pip
   - pip:
     - schemdraw
+    - japanize-matplotlib


### PR DESCRIPTION
Fix #5 

# 概要
japanize-matplotlibを環境設定ファイルに追加する

# 動作確認の方法
environment.ymlあるいはenvironment-windows.ymlを用いて構築したmlnote環境で、`import japanize_matplotlib`を実行してエラーが出ないことを確認する

# 関連するページのリンク
[japanize-matplotlib](https://pypi.org/project/japanize-matplotlib/)